### PR TITLE
Conditionally compile Apple-specific APIs

### DIFF
--- a/rust/wrapper.c
+++ b/rust/wrapper.c
@@ -1,5 +1,6 @@
 #include "wrapper.h"
 
+#if defined(__APPLE__) && defined(__MACH__)
 void os_log_with_type_rs(os_log_t log, os_log_type_t type, const char *message)
 {
     os_log_with_type(log, type, "%{public}s", message);
@@ -14,3 +15,4 @@ void os_signpost_interval_end_rs(os_log_t log, os_signpost_id_t interval_id, con
 {
     os_signpost_interval_end(log, interval_id, "rust", "%{public}s", label);
 }
+#endif

--- a/rust/wrapper.h
+++ b/rust/wrapper.h
@@ -1,3 +1,4 @@
+#if defined(__APPLE__) && defined(__MACH__)
 #include <os/log.h>
 #include <os/signpost.h>
 
@@ -5,3 +6,4 @@ void os_log_with_type_rs(os_log_t log, os_log_type_t type, const char *message);
 
 void os_signpost_interval_begin_rs(os_log_t log, os_signpost_id_t interval_id, const char *label);
 void os_signpost_interval_end_rs(os_log_t log, os_signpost_id_t interval_id, const char *label);
+#endif


### PR DESCRIPTION
This enables development on non-Apple machines, and potentially in future usage of the Swift SDK with non-Apple targets.