### PR TITLE
Send change to Orchard by default

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2742,7 +2742,7 @@ fn zip317_helper<DbT>(
         StandardFeeRule::PreZip313
     };
     GreedyInputSelector::new(
-        SingleOutputChangeStrategy::new(fee_rule, change_memo, ShieldedProtocol::Sapling),
+        SingleOutputChangeStrategy::new(fee_rule, change_memo, ShieldedProtocol::Orchard),
         DustOutputPolicy::default(),
     )
 }


### PR DESCRIPTION
This also modifies shielding behavior so that shielded funds are sent to the Orchard pool instead of to Sapling.