### PR TITLE
Return an error instead of a panic in the case of data corruption.

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -144,15 +144,27 @@ fn account_id_from_ffi<P: Parameters>(
         .filter_map(|account_id| {
             db_data
                 .get_account(account_id)
-                .transpose()
-                .expect("account_id exists")
-                .map(|account| match account.source() {
-                    AccountSource::Derived { account_index, .. }
-                        if account_index == requested_account_index =>
-                    {
-                        Some(account)
-                    }
-                    _ => None,
+                .map_err(|e| {
+                    anyhow!(
+                        "Database error encountered retrieving account {:?}: {}",
+                        account_id,
+                        e
+                    )
+                })
+                .and_then(|acct_opt| {
+                    acct_opt
+                        .ok_or(anyhow!(
+                            "Wallet data corrupted: unable to retrieve account data for account {:?}",
+                            account_id
+                        ))
+                        .map(|account| match account.source() {
+                            AccountSource::Derived { account_index, .. }
+                                if account_index == requested_account_index =>
+                            {
+                                Some(account)
+                            }
+                            _ => None,
+                        })
                 })
                 .transpose()
         });


### PR DESCRIPTION
This removes an `expect` call that risked crashing the app in the case of database corruption, potentially hiding other bugs.