### PR TITLE
Set `MinimumOSVersion` to a wildly-high value

### DIFF
--- a/support/Info.plist
+++ b/support/Info.plist
@@ -47,6 +47,8 @@
 	</array>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
+	<key>MinimumOSVersion</key>
+	<string>100.0</string>
 	<key>XCFrameworkFormatVersion</key>
 	<string>1.0</string>
 </dict>


### PR DESCRIPTION
For whatever reason, this works around a bug in XCode 15.3.

Part of Electric-Coin-Company/zashi-ios#1166.