### PR TITLE
Add dummy `Info.plist` to platform frameworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ products/%/frameworks/libzcashlc.framework: products/%/universal/libzcashlc.a
 	cp -R rust/target/Headers $@
 	mkdir $@/Modules
 	cp support/module.modulemap $@/Modules
+	# Workaround for a bug in the XCode 15.3 build system.
+	# https://github.com/Electric-Coin-Company/zashi-ios/issues/1166
+	cp support/platform-Info.plist $@/Info.plist
 
 products/macos/universal/libzcashlc.a: $(MACOS_ARCHS)
 	mkdir -p $(@D)

--- a/support/platform-Info.plist
+++ b/support/platform-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>libzcashlc</string>
+	<key>CFBundleIdentifier</key>
+	<string>libzcashlc</string>
+	<key>CFBundleName</key>
+	<string>libzcashlc</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleVersion</key>
+	<string>0.7.5</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iphonesimulator</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>100.0</string>
+</dict>
+</plist>


### PR DESCRIPTION
A bug in the XCode 15.3 build system causes a dummy framework folder to be included in the app bundle when it depends on a statically linked framework (like this one). This causes app validation to fail both in the simulator and when pushing an app build to the App Store Connect.

We work around the bug by adding a dummy `Info.plist` to the platform frameworks, with a `MinimumOSVersion` that is wildly high to ensure it can't actually be used.

Part of Electric-Coin-Company/zashi-ios#1166.