### PR TITLE
Update `zcash_client_sqlite` to fix potential note commitment tree corruption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- `zcashlc_rewind_to_height` now returns an `i64` value instead of a boolean. The
+  value `-1` indicates failure; any other height indicates the height to which the
+  data store was actually truncated. Also, this procedure now takes an additional
+  `safe_rewind_ret` parameter that, on failure to rewind, will be set to the
+  minimum height for which the rewind would succeed or will remain unmodified if
+  no such height can be determined.
+
+### Removed
+- `zcashlc_get_nearest_rewind_height` has been removed. The return value of 
+  `zcashlc_rewind_to_height`, or in the case of rewind failure the value of its
+  `safe_rewind_ret` return parameter should be used instead.
+
+### Fixed
+- This release fixes a potential source of corruption in wallet note commitment
+  trees related to incorrect handling of chain reorgs. It includes a database
+  migration that will repair the corrupted database state of any wallet
+  affected by this corner case.
+
 ## 0.9.1 - 2024-08-21
 
 ### Fixed

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
@@ -1008,8 +1008,17 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
                               uint8_t *signature_bytes_ret);
 
 /**
- * Returns the most recent block height to which it is possible to reset the state
- * of the data database.
+ * Rewinds the data database to at most the given height.
+ *
+ * If the requested height is greater than or equal to the height of the last scanned block, this
+ * function does nothing.
+ *
+ * This procedure returns the height to which the database was actually rewound, or `-1` if no
+ * rewind was performed.
+ *
+ * If the requested rewind could not be performed, but a rewind to a different (greater) height
+ * would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
+ * otherwise, it will remain unmodified.
  *
  * # Safety
  *
@@ -1020,30 +1029,11 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
  * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
  *   documentation of pointer::offset.
  */
-int32_t zcashlc_get_nearest_rewind_height(const uint8_t *db_data,
-                                          uintptr_t db_data_len,
-                                          int32_t height,
-                                          uint32_t network_id);
-
-/**
- * Rewinds the data database to the given height.
- *
- * If the requested height is greater than or equal to the height of the last scanned
- * block, this function does nothing.
- *
- * # Safety
- *
- * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
- *   alignment of `1`. Its contents must be a string representing a valid system path in the
- *   operating system's preferred representation.
- * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
- * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
- *   documentation of pointer::offset.
- */
-bool zcashlc_rewind_to_height(const uint8_t *db_data,
-                              uintptr_t db_data_len,
-                              int32_t height,
-                              uint32_t network_id);
+int64_t zcashlc_rewind_to_height(const uint8_t *db_data,
+                                 uintptr_t db_data_len,
+                                 uint32_t height,
+                                 uint32_t network_id,
+                                 uint32_t *safe_rewind_ret);
 
 /**
  * Adds a sequence of Sapling subtree roots to the data store.

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
@@ -1011,17 +1011,18 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
  * Rewinds the data database to at most the given height.
  *
  * If the requested height is greater than or equal to the height of the last scanned block, this
- * function does nothing.
+ * function sets the `safe_rewind_ret` output parameter to `-1` and does nothing else.
  *
  * This procedure returns the height to which the database was actually rewound, or `-1` if no
  * rewind was performed.
  *
  * If the requested rewind could not be performed, but a rewind to a different (greater) height
  * would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
- * otherwise, it will remain unmodified.
+ * otherwise, it will be set to `-1`.
  *
  * # Safety
  *
+ * - `safe_rewind_ret` must be non-null, aligned, and valid for writing a `uint32_t`.
  * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
  *   alignment of `1`. Its contents must be a string representing a valid system path in the
  *   operating system's preferred representation.
@@ -1033,7 +1034,7 @@ int64_t zcashlc_rewind_to_height(const uint8_t *db_data,
                                  uintptr_t db_data_len,
                                  uint32_t height,
                                  uint32_t network_id,
-                                 uint32_t *safe_rewind_ret);
+                                 int64_t *safe_rewind_ret);
 
 /**
  * Adds a sequence of Sapling subtree roots to the data store.

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
@@ -1008,8 +1008,17 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
                               uint8_t *signature_bytes_ret);
 
 /**
- * Returns the most recent block height to which it is possible to reset the state
- * of the data database.
+ * Rewinds the data database to at most the given height.
+ *
+ * If the requested height is greater than or equal to the height of the last scanned block, this
+ * function does nothing.
+ *
+ * This procedure returns the height to which the database was actually rewound, or `-1` if no
+ * rewind was performed.
+ *
+ * If the requested rewind could not be performed, but a rewind to a different (greater) height
+ * would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
+ * otherwise, it will remain unmodified.
  *
  * # Safety
  *
@@ -1020,30 +1029,11 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
  * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
  *   documentation of pointer::offset.
  */
-int32_t zcashlc_get_nearest_rewind_height(const uint8_t *db_data,
-                                          uintptr_t db_data_len,
-                                          int32_t height,
-                                          uint32_t network_id);
-
-/**
- * Rewinds the data database to the given height.
- *
- * If the requested height is greater than or equal to the height of the last scanned
- * block, this function does nothing.
- *
- * # Safety
- *
- * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
- *   alignment of `1`. Its contents must be a string representing a valid system path in the
- *   operating system's preferred representation.
- * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
- * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
- *   documentation of pointer::offset.
- */
-bool zcashlc_rewind_to_height(const uint8_t *db_data,
-                              uintptr_t db_data_len,
-                              int32_t height,
-                              uint32_t network_id);
+int64_t zcashlc_rewind_to_height(const uint8_t *db_data,
+                                 uintptr_t db_data_len,
+                                 uint32_t height,
+                                 uint32_t network_id,
+                                 uint32_t *safe_rewind_ret);
 
 /**
  * Adds a sequence of Sapling subtree roots to the data store.

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
@@ -1011,17 +1011,18 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
  * Rewinds the data database to at most the given height.
  *
  * If the requested height is greater than or equal to the height of the last scanned block, this
- * function does nothing.
+ * function sets the `safe_rewind_ret` output parameter to `-1` and does nothing else.
  *
  * This procedure returns the height to which the database was actually rewound, or `-1` if no
  * rewind was performed.
  *
  * If the requested rewind could not be performed, but a rewind to a different (greater) height
  * would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
- * otherwise, it will remain unmodified.
+ * otherwise, it will be set to `-1`.
  *
  * # Safety
  *
+ * - `safe_rewind_ret` must be non-null, aligned, and valid for writing a `uint32_t`.
  * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
  *   alignment of `1`. Its contents must be a string representing a valid system path in the
  *   operating system's preferred representation.
@@ -1033,7 +1034,7 @@ int64_t zcashlc_rewind_to_height(const uint8_t *db_data,
                                  uintptr_t db_data_len,
                                  uint32_t height,
                                  uint32_t network_id,
-                                 uint32_t *safe_rewind_ret);
+                                 int64_t *safe_rewind_ret);
 
 /**
  * Adds a sequence of Sapling subtree roots to the data store.

--- a/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
@@ -1008,8 +1008,17 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
                               uint8_t *signature_bytes_ret);
 
 /**
- * Returns the most recent block height to which it is possible to reset the state
- * of the data database.
+ * Rewinds the data database to at most the given height.
+ *
+ * If the requested height is greater than or equal to the height of the last scanned block, this
+ * function does nothing.
+ *
+ * This procedure returns the height to which the database was actually rewound, or `-1` if no
+ * rewind was performed.
+ *
+ * If the requested rewind could not be performed, but a rewind to a different (greater) height
+ * would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
+ * otherwise, it will remain unmodified.
  *
  * # Safety
  *
@@ -1020,30 +1029,11 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
  * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
  *   documentation of pointer::offset.
  */
-int32_t zcashlc_get_nearest_rewind_height(const uint8_t *db_data,
-                                          uintptr_t db_data_len,
-                                          int32_t height,
-                                          uint32_t network_id);
-
-/**
- * Rewinds the data database to the given height.
- *
- * If the requested height is greater than or equal to the height of the last scanned
- * block, this function does nothing.
- *
- * # Safety
- *
- * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
- *   alignment of `1`. Its contents must be a string representing a valid system path in the
- *   operating system's preferred representation.
- * - The memory referenced by `db_data` must not be mutated for the duration of the function call.
- * - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
- *   documentation of pointer::offset.
- */
-bool zcashlc_rewind_to_height(const uint8_t *db_data,
-                              uintptr_t db_data_len,
-                              int32_t height,
-                              uint32_t network_id);
+int64_t zcashlc_rewind_to_height(const uint8_t *db_data,
+                                 uintptr_t db_data_len,
+                                 uint32_t height,
+                                 uint32_t network_id,
+                                 uint32_t *safe_rewind_ret);
 
 /**
  * Adds a sequence of Sapling subtree roots to the data store.

--- a/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
@@ -1011,17 +1011,18 @@ bool zcashlc_seed_fingerprint(const uint8_t *seed,
  * Rewinds the data database to at most the given height.
  *
  * If the requested height is greater than or equal to the height of the last scanned block, this
- * function does nothing.
+ * function sets the `safe_rewind_ret` output parameter to `-1` and does nothing else.
  *
  * This procedure returns the height to which the database was actually rewound, or `-1` if no
  * rewind was performed.
  *
  * If the requested rewind could not be performed, but a rewind to a different (greater) height
  * would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
- * otherwise, it will remain unmodified.
+ * otherwise, it will be set to `-1`.
  *
  * # Safety
  *
+ * - `safe_rewind_ret` must be non-null, aligned, and valid for writing a `uint32_t`.
  * - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
  *   alignment of `1`. Its contents must be a string representing a valid system path in the
  *   operating system's preferred representation.
@@ -1033,7 +1034,7 @@ int64_t zcashlc_rewind_to_height(const uint8_t *db_data,
                                  uintptr_t db_data_len,
                                  uint32_t height,
                                  uint32_t network_id,
-                                 uint32_t *safe_rewind_ret);
+                                 int64_t *safe_rewind_ret);
 
 /**
  * Adds a sequence of Sapling subtree roots to the data store.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -309,12 +309,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1762,9 +1756,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75346da3bd8e3d8891d02508245ed2df34447ca6637e343829f8d08986e9cde2"
+checksum = "d45063fbc4b0a37837f6bfe0445f269d13d730ad0aa3b5a7f74aa7bf27a0f4df"
 dependencies = [
  "either",
 ]
@@ -2266,9 +2260,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc7bde644aeb980be296cd908c6650894dc8541deb56f9f5294c52ed7ca568f"
+checksum = "4f18e997fa121de5c73e95cdc7e8512ae43b7de38904aeea5e5713cc48f3c0ba"
 dependencies = [
  "aes",
  "bitvec",
@@ -3119,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e379398fffad84e49f9a45a05635fc004f66086e65942dbf4eb95332c26d2a"
+checksum = "cfff8cfce16aeb38da50b8e2ed33c9018f30552beff2210c266662a021b17f38"
 dependencies = [
  "aes",
  "bellman",
@@ -3301,7 +3295,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3381,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78222845cd8bbe5eb95687407648ff17693a35de5e8abaa39a4681fb21e033f9"
+checksum = "b5f2390975ebfe8838f9e861f7a588123d49a7a7a0a08568ea831d8ad53fc9b4"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -5087,9 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d26f21381dc220836dd8d2a9a10dbe85928a26232b011bc6a42b611789b743"
+checksum = "4ff95eac82f71286a79c750e674550d64fb2b7aadaef7b89286b2917f645457d"
 dependencies = [
  "bech32",
  "bs58",
@@ -5100,13 +5094,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e3a0f3e5d7f299d8b7ef3237697630989c31ab1b162824c99c1cd8bc83715e"
+checksum = "cbeeede366fdb642710d3c59fc2090489affd075f66db53ed11bb7138d2d0258"
 dependencies = [
  "arti-client",
  "async-trait",
- "base64 0.21.7",
+ "base64",
  "bech32",
  "bip32",
  "bls12_381",
@@ -5125,6 +5119,7 @@ dependencies = [
  "nom",
  "nonempty",
  "orchard",
+ "pasta_curves",
  "percent-encoding",
  "prost",
  "rand 0.8.5",
@@ -5158,9 +5153,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9a014103263acf5783804c38c58be9576a3ed8849c9d46a5cd3f0c08e1ff23"
+checksum = "eea43a0c318527c1b15007f70d84078e997a9e1697ebd278ffa60c5ad6b60864"
 dependencies = [
  "bip32",
  "bs58",
@@ -5173,6 +5168,7 @@ dependencies = [
  "nonempty",
  "orchard",
  "prost",
+ "regex",
  "rusqlite",
  "sapling-crypto",
  "schemer",
@@ -5205,9 +5201,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712faf4070107ab0b2828d0eda6aeaf4c3cb02564109832d95b97ad3467c95a5"
+checksum = "e8162c94957f1e379b8e2fb30f97b95cfa93ac9c6bc02895946ca6392d1abb81"
 dependencies = [
  "bech32",
  "bip32",
@@ -5247,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f044bc9cf2887ec408196fbafb44749e5581f57cc18d8da7aabaeb60cc40c64"
+checksum = "6ab47d526d7fd6f88b3a2854ad81b54757a80c2aeadd1d8b06f690556af9743c"
 dependencies = [
  "aes",
  "bip32",
@@ -5286,9 +5282,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c579a5893ac140fab49cf73023ace91d51b441f37094bba5969c775526d8c1e"
+checksum = "daba607872e60d91a09248d8e1ea3d6801c819fb80d67016d9de02d81323c10d"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5309,9 +5305,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35eac659fdbba614333d119217c5963c0d7cea43aee33176c4f2f95e5460d8d"
+checksum = "6bc22b9155b2c7eb20105cd06de170d188c1bc86489b92aa3fda7b8da8d96acf"
 dependencies = [
  "document-features",
  "memuse",
@@ -5380,11 +5376,11 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc85f862f7be64fb0d46f9eb5b82ad54e58cde314fa979d5bae591bc0143693"
+checksum = "1f3e613defb0940acef1f54774b51c7f48f2fa705613dd800870dc69f35cd2ea"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "nom",
  "percent-encoding",
  "zcash_address",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,13 +14,13 @@ build = "build.rs"
 [dependencies]
 
 # Zcash
-orchard = "0.9"
-sapling = { package = "sapling-crypto", version = "0.2", default-features = false }
-zcash_address = { version = "0.4" }
-zcash_client_backend = { version = "0.13", features = ["orchard", "tor", "transparent-inputs", "unstable"] }
-zcash_client_sqlite = { version = "0.11.1", features = ["orchard", "transparent-inputs", "unstable"] }
-zcash_primitives = "0.16"
-zcash_proofs = "0.16"
+orchard = "0.10"
+sapling = { package = "sapling-crypto", version = "0.3", default-features = false }
+zcash_address = { version = "0.6" }
+zcash_client_backend = { version = "0.14", features = ["orchard", "tor", "transparent-inputs", "unstable"] }
+zcash_client_sqlite = { version = "0.12", features = ["orchard", "transparent-inputs", "unstable"] }
+zcash_primitives = "0.19"
+zcash_proofs = "0.19"
 
 # Infrastructure
 prost = "0.13"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,6 +19,7 @@ use tor_rtcompat::BlockOn;
 use tracing::{debug, metadata::LevelFilter};
 use tracing_subscriber::prelude::*;
 use zcash_client_backend::data_api::TransactionStatus;
+use zcash_client_sqlite::error::SqliteClientError;
 
 use zcash_address::{
     unified::{self, Container, Encoding},
@@ -1606,61 +1607,17 @@ pub unsafe extern "C" fn zcashlc_seed_fingerprint(
     unwrap_exc_or(res, false)
 }
 
-/// Returns the most recent block height to which it is possible to reset the state
-/// of the data database.
+/// Rewinds the data database to at most the given height.
 ///
-/// # Safety
+/// If the requested height is greater than or equal to the height of the last scanned block, this
+/// function does nothing.
 ///
-/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
-///   alignment of `1`. Its contents must be a string representing a valid system path in the
-///   operating system's preferred representation.
-/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
-/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
-///   documentation of pointer::offset.
-#[no_mangle]
-pub unsafe extern "C" fn zcashlc_get_nearest_rewind_height(
-    db_data: *const u8,
-    db_data_len: usize,
-    height: i32,
-    network_id: u32,
-) -> i32 {
-    #[allow(deprecated)]
-    let res = catch_panic(|| {
-        if height < 100 {
-            Ok(height)
-        } else {
-            let network = parse_network(network_id)?;
-            let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
-            let height = BlockHeight::try_from(height)?;
-
-            match db_data.get_min_unspent_height() {
-                Ok(Some(best_height)) => {
-                    let first_unspent_note_height = u32::from(best_height);
-                    let rewind_height = u32::from(height);
-                    Ok(std::cmp::min(
-                        first_unspent_note_height as i32,
-                        rewind_height as i32,
-                    ))
-                }
-                Ok(None) => {
-                    let rewind_height = u32::from(height);
-                    Ok(rewind_height as i32)
-                }
-                Err(e) => Err(anyhow!(
-                    "Error while getting nearest rewind height for {}: {}",
-                    height,
-                    e
-                )),
-            }
-        }
-    });
-    unwrap_exc_or(res, -1)
-}
-
-/// Rewinds the data database to the given height.
+/// This procedure returns the height to which the database was actually rewound, or `-1` if no
+/// rewind was performed.
 ///
-/// If the requested height is greater than or equal to the height of the last scanned
-/// block, this function does nothing.
+/// If the requested rewind could not be performed, but a rewind to a different (greater) height
+/// would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
+/// otherwise, it will remain unmodified.
 ///
 /// # Safety
 ///
@@ -1674,20 +1631,36 @@ pub unsafe extern "C" fn zcashlc_get_nearest_rewind_height(
 pub unsafe extern "C" fn zcashlc_rewind_to_height(
     db_data: *const u8,
     db_data_len: usize,
-    height: i32,
+    height: u32,
     network_id: u32,
-) -> bool {
+    safe_rewind_ret: *mut u32,
+) -> i64 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
         let mut db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
 
-        let height = BlockHeight::try_from(height)?;
-        db_data
-            .truncate_to_height(height)
-            .map(|_| true)
-            .map_err(|e| anyhow!("Error while rewinding data DB to height {}: {}", height, e))
+        let height = BlockHeight::from(height);
+        let result_height = db_data.truncate_to_height(height);
+
+        result_height.map_or_else(
+            |err| match err {
+                SqliteClientError::RequestedRewindInvalid {
+                    safe_rewind_height: Some(h),
+                    ..
+                } => {
+                    unsafe { *safe_rewind_ret = h.into() };
+                    Ok(-1)
+                }
+                other => Err(anyhow!(
+                    "Error while rewinding data DB to height {}: {}",
+                    height,
+                    other
+                )),
+            },
+            |h| Ok(u32::from(h).into()),
+        )
     });
-    unwrap_exc_or(res, false)
+    unwrap_exc_or(res, -1)
 }
 
 /// A struct that contains a subtree root.
@@ -2665,8 +2638,8 @@ pub unsafe extern "C" fn zcashlc_decrypt_and_store_transaction(
         let tx = Transaction::read(tx_bytes, BranchId::Sapling)?;
 
         // Following the conventions of the `zcashd` `getrawtransaction` RPC method,
-        // negative values (specifically -1) indicate that the transaction may have been 
-        // mined, but in a fork of the chain rather than the main chain, whereas a value 
+        // negative values (specifically -1) indicate that the transaction may have been
+        // mined, but in a fork of the chain rather than the main chain, whereas a value
         // of zero indicates that the transaction is in the mempool. We do not distinguish
         // between these in `librustzcash`, and so both cases are mapped to `None`,
         // indicating that the mined height of the transaction is simply unknown.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1610,17 +1610,18 @@ pub unsafe extern "C" fn zcashlc_seed_fingerprint(
 /// Rewinds the data database to at most the given height.
 ///
 /// If the requested height is greater than or equal to the height of the last scanned block, this
-/// function does nothing.
+/// function sets the `safe_rewind_ret` output parameter to `-1` and does nothing else.
 ///
 /// This procedure returns the height to which the database was actually rewound, or `-1` if no
 /// rewind was performed.
 ///
 /// If the requested rewind could not be performed, but a rewind to a different (greater) height
 /// would be valid, the `safe_rewind_ret` output parameter will be set to that value on completion;
-/// otherwise, it will remain unmodified.
+/// otherwise, it will be set to `-1`.
 ///
 /// # Safety
 ///
+/// - `safe_rewind_ret` must be non-null, aligned, and valid for writing a `uint32_t`.
 /// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
@@ -1633,8 +1634,11 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
     db_data_len: usize,
     height: u32,
     network_id: u32,
-    safe_rewind_ret: *mut u32,
+    safe_rewind_ret: *mut i64,
 ) -> i64 {
+    unsafe {
+        *safe_rewind_ret = -1;
+    }
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
         let mut db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
@@ -1648,7 +1652,7 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
                     safe_rewind_height: Some(h),
                     ..
                 } => {
-                    unsafe { *safe_rewind_ret = h.into() };
+                    unsafe { *safe_rewind_ret = u32::from(h).into() };
                     Ok(-1)
                 }
                 other => Err(anyhow!(


### PR DESCRIPTION
As part of this change, the `zcashlc_get_nearest_rewind_height` FFI method is removed. The return type of `zcashlc_rewind_to_height` has been changed to an `i64` that represents the height to which the database was actually rewound, or `-1` if the rewind was unsuccessful. Additionally, `zcashlc_rewind_to_height` now takes an output parameter that the Rust backend can use to set the minimum valid rewind height, if any.