### PR TITLE
CI: Change naming pattern for binary preview branches to avoid bugs

### DIFF
--- a/.github/workflows/build-binary-preview.yml
+++ b/.github/workflows/build-binary-preview.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create, or merge into, the corresponding preview branch
-        run: git switch -c '${{ github.ref_name }}-preview' || git switch -m '${{ github.ref_name }}-preview'
+        run: git switch -c 'preview/${{ github.ref_name }}' || git switch -m 'preview/${{ github.ref_name }}'
 
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
       - name: Select the required Xcode version


### PR DESCRIPTION
- After changing from `-` to `/` logical separation, the `-preview` suffix was mis-interpretable as part of the version.
- Using a `preview` suffix would potentially cause the workflow to recursively loop, because the workflow branch filter would match both the release / hotfix branches, and every preview branch. We now use a `preview` prefix to domain-separate the preview branches.