### PR TITLE
CI: Specify branch to commit and push binary previews to

### DIFF
--- a/.github/workflows/build-binary-preview.yml
+++ b/.github/workflows/build-binary-preview.yml
@@ -31,3 +31,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'make xcframework'
+          branch: 'preview/${{ github.ref_name }}'


### PR DESCRIPTION
This is necessary to get the stefanzweifel/git-auto-commit-action@v5 action to set the upstream branch.