### PR TITLE
Fix binary preview

### DIFF
--- a/.github/workflows/build-binary-preview.yml
+++ b/.github/workflows/build-binary-preview.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create, or merge into, the corresponding preview branch
-        run: git switch -c "preview/${GITHUB_REF_NAME}" || git switch -m "preview/${GITHUB_REF_NAME}"
+        run: git switch -m "preview/${GITHUB_REF_NAME}" || git switch -c "preview/${GITHUB_REF_NAME}"
 
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
       - name: Select the required Xcode version

--- a/.github/workflows/build-binary-preview.yml
+++ b/.github/workflows/build-binary-preview.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Create, or merge into, the corresponding preview branch
         run: git switch -c "preview/${GITHUB_REF_NAME}" || git switch -m "preview/${GITHUB_REF_NAME}"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently implemented is building for apple platforms as an `xcframework` and fo
 Add the package as a dependency
 ````Swift
 dependencies: [
-  .package(url: "https://github.com/Electric-Coin-Company/zcash-light-client-ffi", from: "0.1.2")
+  .package(url: "https://github.com/Electric-Coin-Company/zcash-light-client-ffi", exact: "0.12.0")
   // other dependencies
 ]
 ````


### PR DESCRIPTION
This is necessary to discover any existing binary previews for the current branch, so we can merge to it instead of overwriting it.