### PR TITLE
feature: librustzcash update confirmations policy part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `ConfirmationsPolicy`
+
+### Changed
+
+- `zcashlc_get_wallet_summary` now takes `confirmations_policy: ConfirmationsPolicy`
+  instead of `min_confirmations: u32`
+
 ## 0.17.0 - 2025-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `zcashlc_propose_transfer`
   * `zcashlc_propose_send_max_transfer`
   * `zcashlc_propose_transfer_from_uri`
+  * `zcashlc_propose_shielding`
 
 ## 0.17.0 - 2025-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `zcashlc_get_wallet_summary` now takes `confirmations_policy: ConfirmationsPolicy`
-  instead of `min_confirmations: u32`
+- functions now take `confirmations_policy: ConfirmationsPolicy` instead of `min_confirmations: u32`:
+  * `zcashlc_get_wallet_summary` 
+  * `zcashlc_get_verified_transparent_balance`
 
 ## 0.17.0 - 2025-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - functions now take `confirmations_policy: ConfirmationsPolicy` instead of `min_confirmations: u32`:
+
   * `zcashlc_get_wallet_summary` 
   * `zcashlc_get_verified_transparent_balance`
+  * `zcashlc_get_verified_transparent_balance_for_account`
 
 ## 0.17.0 - 2025-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `zcashlc_get_wallet_summary` 
   * `zcashlc_get_verified_transparent_balance`
   * `zcashlc_get_verified_transparent_balance_for_account`
+  * `zcashlc_propose_transfer`
+  * `zcashlc_propose_send_max_transfer`
+  * `zcashlc_propose_transfer_from_uri`
 
 ## 0.17.0 - 2025-06-04
 

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
@@ -173,13 +173,19 @@ typedef struct FFIEncodedKeys {
  */
 typedef struct ConfirmationsPolicy {
   /**
-   * NonZero, zero for default
+   * The number of confirmations required before trusted notes may be spent. NonZero, set this
+   * and `untrusted` to zero to accept the default value for each.
    */
   uint32_t trusted;
   /**
-   * NonZero, zero for default, zero must match `trusted`
+   * The number of confirmations required before untrusted notes may be spent. NonZero, set this
+   * and `trusted` both to zero to accept the default value for each.
    */
   uint32_t untrusted;
+  /**
+   * A flag that enables selection of zero-conf transparent UTXOs for spends in shielding
+   * transactions.
+   */
   bool allow_zero_conf_shielding;
 } ConfirmationsPolicy;
 

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h
@@ -158,6 +158,32 @@ typedef struct FFIEncodedKeys {
 } FFIEncodedKeys;
 
 /**
+ * A description of the policy that is used to determine what notes are available for spending,
+ * based upon the number of confirmations (the number of blocks in the chain since and including
+ * the block in which a note was produced.)
+ *
+ * See [`ZIP 315`] for details including the definitions of "trusted" and "untrusted" notes.
+ *
+ * # Note
+ *
+ * `trusted` and `untrusted` are both meant to be non-zero values.
+ * `0` will be treated as a request for a default value.
+ *
+ * [`ZIP 315`]: https://zips.z.cash/zip-0315
+ */
+typedef struct ConfirmationsPolicy {
+  /**
+   * NonZero, zero for default
+   */
+  uint32_t trusted;
+  /**
+   * NonZero, zero for default, zero must match `trusted`
+   */
+  uint32_t untrusted;
+  bool allow_zero_conf_shielding;
+} ConfirmationsPolicy;
+
+/**
  * A struct that contains a subtree root.
  *
  * # Safety
@@ -974,7 +1000,7 @@ struct FFIEncodedKeys *zcashlc_list_transparent_receivers(const uint8_t *db_data
 
 /**
  * Returns the verified transparent balance for `address`, which ignores utxos that have been
- * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ * received too recently and are not yet deemed spendable according to `confirmations_policy`.
  *
  * # Safety
  *
@@ -991,11 +1017,11 @@ int64_t zcashlc_get_verified_transparent_balance(const uint8_t *db_data,
                                                  uintptr_t db_data_len,
                                                  const char *address,
                                                  uint32_t network_id,
-                                                 uint32_t min_confirmations);
+                                                 struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns the verified transparent balance for `account`, which ignores utxos that have been
- * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ * received too recently and are not yet deemed spendable according to `confirmations_policy`.
  *
  * # Safety
  *
@@ -1014,7 +1040,7 @@ int64_t zcashlc_get_verified_transparent_balance_for_account(const uint8_t *db_d
                                                              uintptr_t db_data_len,
                                                              uint32_t network_id,
                                                              const uint8_t *account_uuid_bytes,
-                                                             uint32_t min_confirmations);
+                                                             struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns the balance for `address`, including all UTXOs that we know about.
@@ -1254,7 +1280,7 @@ int64_t zcashlc_max_scanned_height(const uint8_t *db_data,
 struct FfiWalletSummary *zcashlc_get_wallet_summary(const uint8_t *db_data,
                                                     uintptr_t db_data_len,
                                                     uint32_t network_id,
-                                                    uint32_t min_confirmations);
+                                                    struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns a list of suggested scan ranges based upon the current wallet state.
@@ -1491,7 +1517,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer(const uint8_t *db_data,
                                                int64_t value,
                                                const uint8_t *memo,
                                                uint32_t network_id,
-                                               uint32_t min_confirmations);
+                                               struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Select transaction inputs, compute fees, and construct a proposal for a transaction
@@ -1512,7 +1538,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer(const uint8_t *db_data,
  *   function call.
  * - `payment_uri` must be non-null and must point to a null-terminated UTF-8 string.
  * - `network_id` a u32. 0 for Testnet and 1 for Mainnet
- * - `min_confirmations` number of confirmations of the funds to spend
+ * - `confirmations_policy` number of trusted/untrusted confirmations of the funds to spend
  * - `use_zip317_fees` `true` to use ZIP-317 fees.
  * - Call [`zcashlc_free_boxed_slice`] to free the memory associated with the returned
  *   pointer when done using it.
@@ -1522,7 +1548,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer_from_uri(const uint8_t *db_data,
                                                         const uint8_t *account_uuid_bytes,
                                                         const char *payment_uri,
                                                         uint32_t network_id,
-                                                        uint32_t min_confirmations);
+                                                        struct ConfirmationsPolicy confirmations_policy);
 
 int32_t zcashlc_branch_id_for_height(int32_t height, uint32_t network_id);
 
@@ -1559,7 +1585,7 @@ void zcashlc_string_free(char *s);
  *   individually shielded in transactions that may be temporally clustered. Keeping transparent
  *   activity private is very difficult; caveat emptor.
  * - network_id: The identifier for the network in use: 0 for testnet, 1 for mainnet.
- * - min_confirmations: The number of confirmations that are required for a UTXO to be considered
+ * - confirmations_policy: The minimum number of confirmations that are required for a UTXO to be considered
  *   for shielding.
  *
  * # Safety
@@ -1585,7 +1611,7 @@ struct FfiBoxedSlice *zcashlc_propose_shielding(const uint8_t *db_data,
                                                 uint64_t shielding_threshold,
                                                 const char *transparent_receiver,
                                                 uint32_t network_id,
-                                                uint32_t min_confirmations);
+                                                struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Creates a transaction from the given proposal.

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
@@ -173,13 +173,19 @@ typedef struct FFIEncodedKeys {
  */
 typedef struct ConfirmationsPolicy {
   /**
-   * NonZero, zero for default
+   * The number of confirmations required before trusted notes may be spent. NonZero, set this
+   * and `untrusted` to zero to accept the default value for each.
    */
   uint32_t trusted;
   /**
-   * NonZero, zero for default, zero must match `trusted`
+   * The number of confirmations required before untrusted notes may be spent. NonZero, set this
+   * and `trusted` both to zero to accept the default value for each.
    */
   uint32_t untrusted;
+  /**
+   * A flag that enables selection of zero-conf transparent UTXOs for spends in shielding
+   * transactions.
+   */
   bool allow_zero_conf_shielding;
 } ConfirmationsPolicy;
 

--- a/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/ios-arm64_x86_64-simulator/libzcashlc.framework/Headers/zcashlc.h
@@ -158,6 +158,32 @@ typedef struct FFIEncodedKeys {
 } FFIEncodedKeys;
 
 /**
+ * A description of the policy that is used to determine what notes are available for spending,
+ * based upon the number of confirmations (the number of blocks in the chain since and including
+ * the block in which a note was produced.)
+ *
+ * See [`ZIP 315`] for details including the definitions of "trusted" and "untrusted" notes.
+ *
+ * # Note
+ *
+ * `trusted` and `untrusted` are both meant to be non-zero values.
+ * `0` will be treated as a request for a default value.
+ *
+ * [`ZIP 315`]: https://zips.z.cash/zip-0315
+ */
+typedef struct ConfirmationsPolicy {
+  /**
+   * NonZero, zero for default
+   */
+  uint32_t trusted;
+  /**
+   * NonZero, zero for default, zero must match `trusted`
+   */
+  uint32_t untrusted;
+  bool allow_zero_conf_shielding;
+} ConfirmationsPolicy;
+
+/**
  * A struct that contains a subtree root.
  *
  * # Safety
@@ -974,7 +1000,7 @@ struct FFIEncodedKeys *zcashlc_list_transparent_receivers(const uint8_t *db_data
 
 /**
  * Returns the verified transparent balance for `address`, which ignores utxos that have been
- * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ * received too recently and are not yet deemed spendable according to `confirmations_policy`.
  *
  * # Safety
  *
@@ -991,11 +1017,11 @@ int64_t zcashlc_get_verified_transparent_balance(const uint8_t *db_data,
                                                  uintptr_t db_data_len,
                                                  const char *address,
                                                  uint32_t network_id,
-                                                 uint32_t min_confirmations);
+                                                 struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns the verified transparent balance for `account`, which ignores utxos that have been
- * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ * received too recently and are not yet deemed spendable according to `confirmations_policy`.
  *
  * # Safety
  *
@@ -1014,7 +1040,7 @@ int64_t zcashlc_get_verified_transparent_balance_for_account(const uint8_t *db_d
                                                              uintptr_t db_data_len,
                                                              uint32_t network_id,
                                                              const uint8_t *account_uuid_bytes,
-                                                             uint32_t min_confirmations);
+                                                             struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns the balance for `address`, including all UTXOs that we know about.
@@ -1254,7 +1280,7 @@ int64_t zcashlc_max_scanned_height(const uint8_t *db_data,
 struct FfiWalletSummary *zcashlc_get_wallet_summary(const uint8_t *db_data,
                                                     uintptr_t db_data_len,
                                                     uint32_t network_id,
-                                                    uint32_t min_confirmations);
+                                                    struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns a list of suggested scan ranges based upon the current wallet state.
@@ -1491,7 +1517,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer(const uint8_t *db_data,
                                                int64_t value,
                                                const uint8_t *memo,
                                                uint32_t network_id,
-                                               uint32_t min_confirmations);
+                                               struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Select transaction inputs, compute fees, and construct a proposal for a transaction
@@ -1512,7 +1538,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer(const uint8_t *db_data,
  *   function call.
  * - `payment_uri` must be non-null and must point to a null-terminated UTF-8 string.
  * - `network_id` a u32. 0 for Testnet and 1 for Mainnet
- * - `min_confirmations` number of confirmations of the funds to spend
+ * - `confirmations_policy` number of trusted/untrusted confirmations of the funds to spend
  * - `use_zip317_fees` `true` to use ZIP-317 fees.
  * - Call [`zcashlc_free_boxed_slice`] to free the memory associated with the returned
  *   pointer when done using it.
@@ -1522,7 +1548,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer_from_uri(const uint8_t *db_data,
                                                         const uint8_t *account_uuid_bytes,
                                                         const char *payment_uri,
                                                         uint32_t network_id,
-                                                        uint32_t min_confirmations);
+                                                        struct ConfirmationsPolicy confirmations_policy);
 
 int32_t zcashlc_branch_id_for_height(int32_t height, uint32_t network_id);
 
@@ -1559,7 +1585,7 @@ void zcashlc_string_free(char *s);
  *   individually shielded in transactions that may be temporally clustered. Keeping transparent
  *   activity private is very difficult; caveat emptor.
  * - network_id: The identifier for the network in use: 0 for testnet, 1 for mainnet.
- * - min_confirmations: The number of confirmations that are required for a UTXO to be considered
+ * - confirmations_policy: The minimum number of confirmations that are required for a UTXO to be considered
  *   for shielding.
  *
  * # Safety
@@ -1585,7 +1611,7 @@ struct FfiBoxedSlice *zcashlc_propose_shielding(const uint8_t *db_data,
                                                 uint64_t shielding_threshold,
                                                 const char *transparent_receiver,
                                                 uint32_t network_id,
-                                                uint32_t min_confirmations);
+                                                struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Creates a transaction from the given proposal.

--- a/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
@@ -173,13 +173,19 @@ typedef struct FFIEncodedKeys {
  */
 typedef struct ConfirmationsPolicy {
   /**
-   * NonZero, zero for default
+   * The number of confirmations required before trusted notes may be spent. NonZero, set this
+   * and `untrusted` to zero to accept the default value for each.
    */
   uint32_t trusted;
   /**
-   * NonZero, zero for default, zero must match `trusted`
+   * The number of confirmations required before untrusted notes may be spent. NonZero, set this
+   * and `trusted` both to zero to accept the default value for each.
    */
   uint32_t untrusted;
+  /**
+   * A flag that enables selection of zero-conf transparent UTXOs for spends in shielding
+   * transactions.
+   */
   bool allow_zero_conf_shielding;
 } ConfirmationsPolicy;
 

--- a/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
+++ b/releases/XCFramework/libzcashlc.xcframework/macos-arm64_x86_64/libzcashlc.framework/Headers/zcashlc.h
@@ -158,6 +158,32 @@ typedef struct FFIEncodedKeys {
 } FFIEncodedKeys;
 
 /**
+ * A description of the policy that is used to determine what notes are available for spending,
+ * based upon the number of confirmations (the number of blocks in the chain since and including
+ * the block in which a note was produced.)
+ *
+ * See [`ZIP 315`] for details including the definitions of "trusted" and "untrusted" notes.
+ *
+ * # Note
+ *
+ * `trusted` and `untrusted` are both meant to be non-zero values.
+ * `0` will be treated as a request for a default value.
+ *
+ * [`ZIP 315`]: https://zips.z.cash/zip-0315
+ */
+typedef struct ConfirmationsPolicy {
+  /**
+   * NonZero, zero for default
+   */
+  uint32_t trusted;
+  /**
+   * NonZero, zero for default, zero must match `trusted`
+   */
+  uint32_t untrusted;
+  bool allow_zero_conf_shielding;
+} ConfirmationsPolicy;
+
+/**
  * A struct that contains a subtree root.
  *
  * # Safety
@@ -974,7 +1000,7 @@ struct FFIEncodedKeys *zcashlc_list_transparent_receivers(const uint8_t *db_data
 
 /**
  * Returns the verified transparent balance for `address`, which ignores utxos that have been
- * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ * received too recently and are not yet deemed spendable according to `confirmations_policy`.
  *
  * # Safety
  *
@@ -991,11 +1017,11 @@ int64_t zcashlc_get_verified_transparent_balance(const uint8_t *db_data,
                                                  uintptr_t db_data_len,
                                                  const char *address,
                                                  uint32_t network_id,
-                                                 uint32_t min_confirmations);
+                                                 struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns the verified transparent balance for `account`, which ignores utxos that have been
- * received too recently and are not yet deemed spendable according to `min_confirmations`.
+ * received too recently and are not yet deemed spendable according to `confirmations_policy`.
  *
  * # Safety
  *
@@ -1014,7 +1040,7 @@ int64_t zcashlc_get_verified_transparent_balance_for_account(const uint8_t *db_d
                                                              uintptr_t db_data_len,
                                                              uint32_t network_id,
                                                              const uint8_t *account_uuid_bytes,
-                                                             uint32_t min_confirmations);
+                                                             struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns the balance for `address`, including all UTXOs that we know about.
@@ -1254,7 +1280,7 @@ int64_t zcashlc_max_scanned_height(const uint8_t *db_data,
 struct FfiWalletSummary *zcashlc_get_wallet_summary(const uint8_t *db_data,
                                                     uintptr_t db_data_len,
                                                     uint32_t network_id,
-                                                    uint32_t min_confirmations);
+                                                    struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Returns a list of suggested scan ranges based upon the current wallet state.
@@ -1491,7 +1517,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer(const uint8_t *db_data,
                                                int64_t value,
                                                const uint8_t *memo,
                                                uint32_t network_id,
-                                               uint32_t min_confirmations);
+                                               struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Select transaction inputs, compute fees, and construct a proposal for a transaction
@@ -1512,7 +1538,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer(const uint8_t *db_data,
  *   function call.
  * - `payment_uri` must be non-null and must point to a null-terminated UTF-8 string.
  * - `network_id` a u32. 0 for Testnet and 1 for Mainnet
- * - `min_confirmations` number of confirmations of the funds to spend
+ * - `confirmations_policy` number of trusted/untrusted confirmations of the funds to spend
  * - `use_zip317_fees` `true` to use ZIP-317 fees.
  * - Call [`zcashlc_free_boxed_slice`] to free the memory associated with the returned
  *   pointer when done using it.
@@ -1522,7 +1548,7 @@ struct FfiBoxedSlice *zcashlc_propose_transfer_from_uri(const uint8_t *db_data,
                                                         const uint8_t *account_uuid_bytes,
                                                         const char *payment_uri,
                                                         uint32_t network_id,
-                                                        uint32_t min_confirmations);
+                                                        struct ConfirmationsPolicy confirmations_policy);
 
 int32_t zcashlc_branch_id_for_height(int32_t height, uint32_t network_id);
 
@@ -1559,7 +1585,7 @@ void zcashlc_string_free(char *s);
  *   individually shielded in transactions that may be temporally clustered. Keeping transparent
  *   activity private is very difficult; caveat emptor.
  * - network_id: The identifier for the network in use: 0 for testnet, 1 for mainnet.
- * - min_confirmations: The number of confirmations that are required for a UTXO to be considered
+ * - confirmations_policy: The minimum number of confirmations that are required for a UTXO to be considered
  *   for shielding.
  *
  * # Safety
@@ -1585,7 +1611,7 @@ struct FfiBoxedSlice *zcashlc_propose_shielding(const uint8_t *db_data,
                                                 uint64_t shielding_threshold,
                                                 const char *transparent_receiver,
                                                 uint32_t network_id,
-                                                uint32_t min_confirmations);
+                                                struct ConfirmationsPolicy confirmations_policy);
 
 /**
  * Creates a transaction from the given proposal.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.3",
  "cexpr",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -74,7 +74,7 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 
 [build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72"
 cbindgen = "0.29"
 cc = "1.0"
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1096,10 +1096,14 @@ pub unsafe extern "C" fn zcashlc_free_http_response_bytes(ptr: *mut HttpResponse
 /// [`ZIP 315`]: https://zips.z.cash/zip-0315
 #[repr(C)]
 pub struct ConfirmationsPolicy {
-    /// NonZero, zero for default
+    /// The number of confirmations required before trusted notes may be spent. NonZero, set this
+    /// and `untrusted` to zero to accept the default value for each.
     pub(crate) trusted: u32,
-    /// NonZero, zero for default, zero must match `trusted`
+    /// The number of confirmations required before untrusted notes may be spent. NonZero, set this
+    /// and `trusted` both to zero to accept the default value for each.
     pub(crate) untrusted: u32,
+    /// A flag that enables selection of zero-conf transparent UTXOs for spends in shielding
+    /// transactions.
     pub(crate) allow_zero_conf_shielding: bool,
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1474,18 +1474,12 @@ pub unsafe extern "C" fn zcashlc_get_wallet_summary(
     db_data: *const u8,
     db_data_len: usize,
     network_id: u32,
-    min_confirmations: u32,
+    confirmations_policy: ffi::ConfirmationsPolicy,
 ) -> *mut ffi::WalletSummary {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
         let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
-
-        let confirmations_policy = match NonZeroU32::new(min_confirmations) {
-            Some(min_confirmations) => {
-                wallet::ConfirmationsPolicy::new_symmetrical(min_confirmations, false)
-            }
-            None => wallet::ConfirmationsPolicy::new_symmetrical(NonZeroU32::MIN, true),
-        };
+        let confirmations_policy = wallet::ConfirmationsPolicy::try_from(confirmations_policy)?;
 
         match db_data
             .get_wallet_summary(confirmations_policy)


### PR DESCRIPTION
This PR stacks on #236 and changes the FFI API to include `ConfirmationsPolicy`.