### PR TITLE
Update to `zcash_client_sqlite 0.18.3`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6216,9 +6216,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eea98c4f5b5697ffba467452e71f324d85fa69c492f2e4393049ea62a783ce"
+checksum = "aca73c9b8a98cb698e283bec976f9cf9512b545ddc6bfcaf66d55f64299163a5"
 dependencies = [
  "bip32",
  "bitflags 2.9.3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.20", features = [
     "transparent-inputs",
     "unstable",
 ] }
-zcash_client_sqlite = { version = "0.18.2", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.18.3", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.25"
 zcash_proofs = "0.25"


### PR DESCRIPTION
This will be merged via direct push with build artifacts to the hotfix/0.18.2 branch.
